### PR TITLE
chore(readme): delete legacy discussion on old versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,17 +108,3 @@ class HelloWorld extends AggregateProgram with StandardSensors with ScafiAlchemi
   }
 }
 ```
-
-## On this version and past versions
-
-I will try to keep this repository aligned with the latest versions of scafi and Alchemist.
-
-However, I have also set up different branches to "freeze" particular project configurations that have proven to work.
-These can be checked out through the usual git branch mechanism, e.g.:
-
-`git checkout scafi-0.3.2-alchemist-9.2.1`
-
-Available branches/configurations:
-
-- `scafi-0.3.2-alchemist-9.2.1`
-- `scafi-0.3.3-alchemist-11.3.0`


### PR DESCRIPTION
Also @metaphori the way to capture persistent references is via tags, not branches